### PR TITLE
Update sim_sdio.pl

### DIFF
--- a/bench/verilog/sim_sdio.pl
+++ b/bench/verilog/sim_sdio.pl
@@ -157,7 +157,7 @@ sub simline($) {
 			## {{{
 			$tstamp = timestamp();
 			system "echo \"$tstamp -- Starting simulation\" | tee -a $sim_log";
-			system "$exefile >> $sim_log";
+			system "./$exefile >> $sim_log";
 
 			## Finish the log with another timestamp
 			## {{{


### PR DESCRIPTION
This fixes the error:

```
sh: 1: sdiosim: not found
```

Explanation: Some people don't have the current working directory `.` in their $PATH.